### PR TITLE
Correcting issue when package is referenced from an es6 app. Currentl…

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.DS_Store*
 .eslintrc
 .eslintignore
 
@@ -6,6 +7,4 @@
 /.travis.yml
 /.npmignore
 
-/src
-/test
 /coverage

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spur-errors",
   "description": "Common error builder utility for Node.js. Contains common error types, and stack trace tracking to support more detailed error messages.",
-  "version": "0.2.0-rc.1",
+  "version": "0.2.0-rc.2",
   "main": "lib/SpurErrors.js",
   "jsnext:main": "./src/SpurErrors",
   "author": {


### PR DESCRIPTION
…y define the main script as:

`"jsnext:main": "./src/SpurErrors",`

However, we had the src directory in the `.npmignore` on the file so the refs wouldn't work and eslint would complain about it.