### PR TITLE
Removing coveralls/coverage testing

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,2 +1,0 @@
-instrumentation:
-    root: src

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "test-unit-legacy": "babel-node --debug node_modules/mocha/bin/_mocha ./test/legacy/",
     "test-integration": "babel-node --debug node_modules/mocha/bin/_mocha ./test/integration/",
     "test": "npm run test-unit && npm run test-unit-legacy && npm run test-integration",
-    "coverage": "babel-node node_modules/isparta/bin/isparta cover --report text --report html ./node_modules/mocha/bin/_mocha --report lcovonly -- ./test/unit/",
-    "precoveralls": "npm run build && npm run lint && npm run test-unit-legacy && npm run test-integration",
-    "coveralls": "npm run coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage",
     "build-and-test": "npm run build && npm test"
   },
   "bugs": {
@@ -48,13 +45,10 @@
     "babel-preset-es2015-loose": "^7.0.0",
     "chai": "^3.5.0",
     "coffee-script": "^1.10.0",
-    "coveralls": "^2.11.6",
     "eslint": "^2.4.0",
     "eslint-config-opentable": "^4.0.0",
     "eslint-plugin-import": "^1.8.1",
-    "isparta": "^4.0.0",
     "mocha": "^2.4.5",
-    "mocha-lcov-reporter": "^1.2.0",
     "sinon": "^1.17.3"
   }
 }


### PR DESCRIPTION
This is a temporary move. The mixture of coffee and es6 keeps making this task difficult and don't want to focus on that everytime there is a new change.