### PR TITLE
add plugin to transform object assign

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["es2015-loose"],
-  "plugins": ["add-module-exports"],
+  "plugins": ["add-module-exports", "transform-object-assign"],
   "sourceMaps": "both",
   "retainLines": "true"
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "babel-cli": "^6.5.1",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-es2015-loose": "^7.0.0",
     "chai": "^3.5.0",


### PR DESCRIPTION
Discovered in https://github.com/opentable/spur-mockserver/pull/15 that the current configuration does not provide any support for `Object.assign` (defined in ES2015) in older Node.js runtimes that don't support it.