### PR TITLE
Updating devDependencies and removing unsupported node versions from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: node_js
 node_js:
-- '0.10'
-- '0.11'
-- '0.12'
 - '4'
-- '5'
 - '6'
 script: npm run build-and-test

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 Common error builder utility for [Node.js](http://nodejs.org/). Contains common error types, and stack trace tracking to support more detailed error messages.
 
-[![NPM version](https://badge.fury.io/js/spur-errors.png)](http://badge.fury.io/js/spur-errors)
-[![Build Status](https://travis-ci.org/opentable/spur-errors.png?branch=master)](https://travis-ci.org/opentable/spur-errors)
-[![Coverage Status](https://coveralls.io/repos/github/opentable/spur-errors/badge.svg?branch=master)](https://coveralls.io/github/opentable/spur-errors?branch=master)
+[![npm version](https://badge.fury.io/js/spur-errors.svg)](http://badge.fury.io/js/spur-errors)
+[![Build Status](https://travis-ci.org/opentable/spur-errors.svg?branch=master)](https://travis-ci.org/opentable/spur-errors)
+[![Dependencies](https://david-dm.org/opentable/spur-errors.svg)](https://david-dm.org/opentable/spur-errors)
+[![devDependency Status](https://david-dm.org/opentable/spur-errors/dev-status.svg)](https://david-dm.org/opentable/spur-errors?type=dev)
 
 # About the Spur Framework
 
@@ -13,6 +14,8 @@ The Spur Framework is a collection of commonly used Node.JS libraries used to cr
 [Visit NPMJS.org for a full list of Spur Framework libraries](https://www.npmjs.com/browse/keyword/spur-framework) >>
 
 # Usage
+
+Supports active Node versions in the [LTS Schedule](https://github.com/nodejs/LTS#lts-schedule). ([view current versions](.travis.yml))
 
 ## Install from NPM
 
@@ -147,6 +150,8 @@ $ npm install
 $ npm run build
 $ npm test
 ```
+
+> Requires Node 4+ for dev tools, but we recommend using Node 6.
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -19,14 +19,17 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "babel src -d lib --source-maps",
-    "dev": "babel --watch src -d lib",
+    "clean": "rm -rf lib/",
+    "build": "npm run clean && babel src -d lib --source-maps",
+    "dev": "npm run clean && babel --watch src -d lib",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test-unit": "babel-node --debug node_modules/mocha/bin/_mocha ./test/unit/",
     "test-integration": "babel-node --debug node_modules/mocha/bin/_mocha ./test/integration/",
     "test": "npm run test-unit && npm run test-integration",
-    "build-and-test": "npm run build && npm test"
+    "build-and-test": "npm run build && npm test",
+    "preversion": "npm run build-and-test",
+    "prepublish": "npm run test"
   },
   "bugs": {
     "url": "https://github.com/opentable/spur-errors/issues"
@@ -38,16 +41,17 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "babel-cli": "^6.5.1",
+    "babel-cli": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-object-assign": "^6.8.0",
-    "babel-preset-es2015": "^6.5.0",
-    "babel-preset-es2015-loose": "^7.0.0",
+    "babel-plugin-transform-regenerator": "6.16.1",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-es2015-loose": "^8.0.0",
     "chai": "^3.5.0",
-    "eslint": "^2.4.0",
-    "eslint-config-opentable": "^4.0.0",
-    "eslint-plugin-import": "^1.8.1",
-    "mocha": "^2.4.5",
+    "eslint": "^3.13.1",
+    "eslint-config-opentable": "^6.0.0",
+    "eslint-plugin-import": "^2.2.0",
+    "mocha": "^3.2.0",
     "sinon": "^1.17.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test": "npm run test-unit && npm run test-integration",
     "build-and-test": "npm run build && npm test",
     "preversion": "npm run build-and-test",
-    "prepublish": "npm run test"
+    "prepublish": "npm run test",
+    "postinstall": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/opentable/spur-errors/issues"

--- a/src/BaseError.js
+++ b/src/BaseError.js
@@ -1,7 +1,7 @@
 const BaseError = {
   create(message, internalError) {
     Error.captureStackTrace(this);
-    const error = Object.assign(new Error, BaseError);
+    const error = Object.assign(new Error(), BaseError);
     if (message) {
       error.message = message;
     }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -17,6 +17,7 @@
     "no-unused-expressions": 0,
     "max-len": 0,
     "arrow-body-style": 0,
-    "no-console": 0
+    "no-console": 0,
+    "import/no-extraneous-dependencies": 0
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -18,6 +18,7 @@
     "max-len": 0,
     "arrow-body-style": 0,
     "no-console": 0,
-    "import/no-extraneous-dependencies": 0
+    "import/no-extraneous-dependencies": 0,
+    "import/no-unresolved": 0
   }
 }

--- a/test/globals.js
+++ b/test/globals.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const chai = require('chai');
+
 global.chai = chai;
 global.expect = chai.expect;
 global.srcDir = path.resolve(__dirname, '../src');


### PR DESCRIPTION

* Removing Node 0.10, 0.11, 0.12, and 5 from .travis.yml to only run tests on supported LTS versions
* Updating devDependencies
* Fixing code related to updating the version of eslint-config-opentable which had a few small changes to the syntax rules
* Adding "babel-plugin-transform-regenerator": "6.16.1" to resolve the build issue