### PR TITLE
Switching to non-transpiled es6/node6 code

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,0 @@
-{
-  "presets": ["es2015-loose"],
-  "plugins": ["add-module-exports", "transform-object-assign"],
-  "sourceMaps": "both",
-  "retainLines": "true"
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,37 @@
 {
-  "extends": "opentable",
   "env": {
+    "es6": true,
     "node": true
+  },
+  "plugins": ["node"],
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
+  "rules": {
+    "node/no-unsupported-features": [2, {
+        "version": 6
+      }
+    ],
+    "arrow-parens": ["error", "always"],
+    "no-shadow": 0,
+    "radix": 0,
+    "keyword-spacing": 0,
+    "consistent-return": 0,
+    "arrow-body-style": 0,
+    "no-use-before-define": 0,
+    "quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true
+      }
+    ],
+    "semi": ["error", "always"],
+    "one-var": [
+      "error",
+      {
+        "uninitialized": "always"
+      }
+    ]
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-- '4'
 - '6'
-script: npm run build-and-test
+- '8'
+script: npm run test

--- a/README.md
+++ b/README.md
@@ -147,11 +147,8 @@ To run the test suite, first install the dependancies, then run `npm test`
 
 ```bash
 $ npm install
-$ npm run build
 $ npm test
 ```
-
-> Requires Node 4+ for dev tools, but we recommend using Node 6.
 
 # License
 

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "spur-errors",
   "description": "Common error builder utility for Node.js. Contains common error types, and stack trace tracking to support more detailed error messages.",
   "version": "0.2.6",
-  "main": "lib/SpurErrors.js",
-  "jsnext:main": "./src/SpurErrors",
+  "main": "./src/SpurErrors",
   "author": {
     "name": "Agustin Colchado",
     "email": "agustin@colchado.com"
@@ -19,15 +18,9 @@
   ],
   "license": "MIT",
   "scripts": {
-    "clean": "rm -rf lib/",
-    "build": "npm run clean && babel src -d lib --source-maps",
-    "dev": "npm run clean && babel --watch src -d lib",
-    "lint": "eslint .",
+    "lint": "eslint ./{src,test}/**/*.js index.js",
     "pretest": "npm run lint",
-    "test-unit": "babel-node --debug node_modules/mocha/bin/_mocha ./test/unit/",
-    "test-integration": "babel-node --debug node_modules/mocha/bin/_mocha ./test/integration/",
-    "test": "npm run test-unit && npm run test-integration",
-    "build-and-test": "npm run build && npm test"
+    "test": "mocha test/"
   },
   "bugs": {
     "url": "https://github.com/opentable/spur-errors/issues"
@@ -39,17 +32,13 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "babel-cli": "^6.18.0",
-    "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-object-assign": "^6.8.0",
-    "babel-plugin-transform-regenerator": "6.16.1",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-es2015-loose": "^8.0.0",
-    "chai": "^3.5.0",
-    "eslint": "^3.13.1",
-    "eslint-config-opentable": "^6.0.0",
-    "eslint-plugin-import": "^2.2.0",
-    "mocha": "^3.2.0",
-    "sinon": "^1.17.3"
+    "chai": "^4.1.1",
+    "eslint": "^4.5.0",
+    "eslint-plugin-node": "^5.1.1",
+    "mocha": "^3.5.0",
+    "sinon": "^3.2.1"
+  },
+  "engines": {
+    "node": ">=6.0.0"
   }
 }

--- a/src/BaseError.js
+++ b/src/BaseError.js
@@ -51,4 +51,4 @@ const BaseError = {
   }
 };
 
-export default BaseError;
+module.exports = BaseError;

--- a/src/SpurErrors.js
+++ b/src/SpurErrors.js
@@ -1,4 +1,4 @@
-import BaseError from './BaseError';
+const BaseError = require('./BaseError');
 
 const SpurErrors = {
   BaseError,
@@ -27,4 +27,4 @@ const SpurErrors = {
   }
 };
 
-export default SpurErrors;
+module.exports = SpurErrors;

--- a/test/fixtures/Callee.js
+++ b/test/fixtures/Callee.js
@@ -1,6 +1,7 @@
-import SpurErrors from '../../src/SpurErrors';
+const SpurErrors = require('../../src/SpurErrors');
 
 module.exports = {
+
   run() {
     return SpurErrors.NotFoundError.create();
   }

--- a/test/integration/DependenciesSpec.js
+++ b/test/integration/DependenciesSpec.js
@@ -1,7 +1,0 @@
-import SpurErrors from '../../lib/SpurErrors';
-
-describe('Integration Dependencies', () => {
-  it('should exist', () => {
-    expect(SpurErrors).to.exist;
-  });
-});

--- a/test/unit/ModuleSpec.js
+++ b/test/unit/ModuleSpec.js
@@ -1,0 +1,12 @@
+const SpurErrorsModule = require('../../');
+const SpurErrorsSource = require('../../src/SpurErrors');
+
+describe('Module Integration', () => {
+  it('the module should be referenced from the root using what\'s defined in the package', () => {
+    expect(SpurErrorsModule).to.exist;
+  });
+
+  it('the module should be the same as the expected source', () => {
+    expect(SpurErrorsModule).to.equal(SpurErrorsSource);
+  });
+});

--- a/test/unit/SpurErrorsSpec.js
+++ b/test/unit/SpurErrorsSpec.js
@@ -1,5 +1,5 @@
-import SpurErrors from '../../src/SpurErrors';
-import Callee from '../fixtures/Callee';
+const SpurErrors = require('../../src/SpurErrors');
+const Callee = require('../fixtures/Callee');
 
 describe('SpurErrors;', () => {
   it('test error', () => {


### PR DESCRIPTION
Getting rid of es6 transpilation and verifying that the code continues to work with the min node 6 version.

This will be published as a major version to attempt prevent the impact to non-node 6 users. Only will work if they aren't using the latest wildcards. :)